### PR TITLE
Fix EZP-27073 Beginner tutorial: Incorrect assets loading order

### DIFF
--- a/ezplatform/app/Resources/views/pagelayout.html.twig
+++ b/ezplatform/app/Resources/views/pagelayout.html.twig
@@ -131,7 +131,8 @@
     </div>
   </div>
 </footer>
-{% javascripts 'assets/js/*' %}
+{% javascripts 'assets/js/jquery.min.js'
+                'assets/js/*' %}
 <script src="{{ asset_url }}"></script>
 {% endjavascripts %}
 <!-- jQuery -->


### PR DESCRIPTION
**Jira ticket**: [https://jira.ez.no/browse/EZP-27073](https://jira.ez.no/browse/EZP-27073)

**Description**:
JavaScript assets loading order fixed.